### PR TITLE
Remove non-std wire.begin() call

### DIFF
--- a/src/ScioSense_ENS160.cpp
+++ b/src/ScioSense_ENS160.cpp
@@ -344,7 +344,11 @@ bool ScioSense_ENS160::set_envdata210(uint16_t t, uint16_t h) {
 /**************************************************************************/
 
 void ScioSense_ENS160::_i2c_init() {
-	Wire.begin();
+#if defined(ESP32)
+	if (this->_sdaPin != this->_sclPin) Wire.begin(this->_sdaPin, this->_sclPin);
+	else
+#endif
+	 Wire.begin();
 }
 
 /**************************************************************************/

--- a/src/ScioSense_ENS160.cpp
+++ b/src/ScioSense_ENS160.cpp
@@ -344,8 +344,7 @@ bool ScioSense_ENS160::set_envdata210(uint16_t t, uint16_t h) {
 /**************************************************************************/
 
 void ScioSense_ENS160::_i2c_init() {
-	if (this->_sdaPin != this->_sclPin) Wire.begin(this->_sdaPin, this->_sclPin);
-	else Wire.begin();
+	Wire.begin();
 }
 
 /**************************************************************************/


### PR DESCRIPTION
For #1. Tested on UNO, QT PY M0, and QT PY ESP32 using `ens160basic_std.ino` example.

@ladyada For review. This is the minimal change required. Others things that *could* be done:
* clang-format
* add CI
* add to Arduino lib man and make a release