### PR TITLE
Bring our fork up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To build an example sketch
  - Select Sketch > Verify/Compile.
 
 ## Functions
-> bool begin(bool debug=false, bool bootloader=false)
+> bool begin(bool debug=false)
 
 Required to initialize the sensor during startup. The function takes up to two arguments: 
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,24 @@ Returns true in case of success and false in case of any issues.
 	
 >	bool	measure(bool waitForNew = True)
 
-Performs the sensor measurement, which means that values from the ASIC internal registers will be stored as result in internal variables. 
+Performs the sensor measurement of the prediction values, which means that values from the ASIC internal registers will be stored as result in internal variables. 
 
 If the variable *waitForNew* is set (default), the function will only terminate once new data is stored in the ASIC internal registers. Due to the measurement frequency this can take up to 1sec. 
 
 If the variable *waitForNew* is not set, the function might terminate with pervious non-updates results stored in the internal variables.
 
 Returns true in case of success and false in case of any issues.
+
+>	bool	measureRaw(bool waitForNew = True)
+
+Performs the sensor measurement of raw signals, which means that values from the ASIC internal registers will be stored as result in internal variables. 
+
+If the variable *waitForNew* is set (default), the function will only terminate once new data is stored in the ASIC internal registers. Due to the measurement frequency this can take up to 1sec. 
+
+If the variable *waitForNew* is not set, the function might terminate with pervious non-updates results stored in the internal variables.
+
+Returns true in case of success and false in case of any issues.
+
 
 >	bool	set_envdata210(uint16_t t, uint16_t h)
 

--- a/examples/ens160basic_custom/ens160basic_custom.ino
+++ b/examples/ens160basic_custom/ens160basic_custom.ino
@@ -66,7 +66,7 @@ void setup() {
 void loop() {
   
   if (ens160.available()) {
-    ens160.measure();
+    ens160.measureRaw(true);
   
     Serial.print("R HP0: ");Serial.print(ens160.getHP0());Serial.print("Ohm\t");
     Serial.print("R HP1: ");Serial.print(ens160.getHP1());Serial.print("Ohm\t");

--- a/examples/ens160basic_std/ens160basic_std.ino
+++ b/examples/ens160basic_std/ens160basic_std.ino
@@ -57,7 +57,8 @@ void setup() {
 void loop() {
   
   if (ens160.available()) {
-    ens160.measure(0);
+    ens160.measure(true);
+    ens160.measureRaw(true);
   
     Serial.print("AQI: ");Serial.print(ens160.getAQI());Serial.print("\t");
     Serial.print("TVOC: ");Serial.print(ens160.getTVOC());Serial.print("ppb\t");

--- a/examples/ens160envdata/ens160envdata.ino
+++ b/examples/ens160envdata/ens160envdata.ino
@@ -92,7 +92,8 @@ void loop() {
       ens210.measure();
       ens160.set_envdata210(ens210.getDataT(),ens210.getDataH());
     }
-    ens160.measure();
+    ens160.measure(true);
+    ens160.measureRaw(true);
   }
   
   Serial.print("AQI: ");Serial.print(ens160.getAQI());Serial.print("\t");

--- a/keywords.txt
+++ b/keywords.txt
@@ -22,21 +22,24 @@ ScioSense_ens160	KEYWORD1
 begin				KEYWORD2
 setI2C				KEYWORD2
 available			KEYWORD2
+revENS16x			KEYWORD2
 setMode				KEYWORD2
 
 initCustomMode		KEYWORD2
 addCustomStep		KEYWORD2
 
-measure				KEYWORD2
+measure				  KEYWORD2
+measureRaw  	  KEYWORD2
 set_envdata			KEYWORD2
-set_envdata210		KEYWORD2
+set_envdata210	KEYWORD2
 getMajorRev			KEYWORD2
 getMinorRev			KEYWORD2
-getBuild			KEYWORD2
+getBuild			  KEYWORD2
 
 getAQI				KEYWORD2
 getTVOC				KEYWORD2
 geteCO2				KEYWORD2
+getAQI500			KEYWORD2
 getHP0				KEYWORD2
 getHP0BL			KEYWORD2
 getHP1				KEYWORD2
@@ -47,14 +50,13 @@ getHP3				KEYWORD2
 getHP3BL			KEYWORD2
 getMISR				KEYWORD2
 
-flashFW				KEYWORD2
-
 ######################################
 # Constants (LITERAL1)
 #######################################
 
 ENS160_I2CADDR_0			LITERAL1
 ENS160_I2CADDR_1			LITERAL1
-ENS160_OPMODE_IDLE			LITERAL1
+ENS160_OPMODE_IDLE		LITERAL1
 ENS160_OPMODE_STD			LITERAL1
-ENS160_OPMODE_CUSTOM		LITERAL1
+ENS160_OPMODE_LP			LITERAL1
+ENS160_OPMODE_CUSTOM	LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=ScioSense ENS160
+name=ENS160 - Adafruit Fork
 version=3.0.0
-author=Christoph Friese
-maintainer=ScioSense
+author=Adafruit
+maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the ENS160 digital four channel MOX gas sensor with I2C interface from ScioSense
 paragraph=This library controls the ENS160. The main feature of this library is performing a single shot measurement, retrieving the measurement data. 
 category=Device Control
-url=https://github.com/sciosense/ens160
+url=https://github.com/adafruit/ENS160_driver
 architectures=*

--- a/src/ScioSense_ENS160.cpp
+++ b/src/ScioSense_ENS160.cpp
@@ -113,7 +113,7 @@ bool ScioSense_ENS160::checkPartID(void) {
 	delay(ENS160_BOOTING);                   // Wait to boot after reset
 
 	if (part_id == ENS160_PARTID) { this->_revENS16x = 0; result = true; }
-	else if (part_id == ENS161_PARTID) { this->_revENS16x = 0; result = true; }
+	else if (part_id == ENS161_PARTID) { this->_revENS16x = 1; result = true; }
 	
 	return result;
 }

--- a/src/ScioSense_ENS160.cpp
+++ b/src/ScioSense_ENS160.cpp
@@ -288,6 +288,7 @@ bool ScioSense_ENS160::measure(bool waitForNew) {
 		_data_tvoc = i2cbuf[1] | ((uint16_t)i2cbuf[2] << 8);
 		_data_eco2 = i2cbuf[3] | ((uint16_t)i2cbuf[4] << 8);
 		if (_revENS16x > 0) _data_aqi500 = ((uint16_t)i2cbuf[5]) | ((uint16_t)i2cbuf[6] << 8);
+		else _data_aqi500 = 0;
 	}
 	
 	return newData;

--- a/src/ScioSense_ENS160.cpp
+++ b/src/ScioSense_ENS160.cpp
@@ -43,7 +43,7 @@ void ScioSense_ENS160::setI2C(uint8_t sda, uint8_t scl) {
 }	
 
 // Init I2C communication, resets ENS160 and checks its PART_ID. Returns false on I2C problems or wrong PART_ID.
-bool ScioSense_ENS160::begin(bool debug, bool bootloader) 
+bool ScioSense_ENS160::begin(bool debug) 
 {
 	debugENS160 = debug;
 
@@ -71,22 +71,12 @@ bool ScioSense_ENS160::begin(bool debug, bool bootloader)
 	this->_available = this->checkPartID();
 
 	if (this->_available) {
-		//Either select bootloader or idle mode
-		if (bootloader) {
-			this->_available = this->setMode(ENS160_OPMODE_BOOTLOADER); 
-		} else {
-			this->_available = this->setMode(ENS160_OPMODE_IDLE);	
-		}
-		
+		this->_available = this->setMode(ENS160_OPMODE_IDLE);	
 		this->_available = this->clearCommand();
 		this->_available = this->getFirmware();
 	}
 	if (debugENS160) {
-		if (bootloader) {
-			Serial.println("ENS160 in bootloader mode"); 
-		} else {
-			Serial.println("ENS160 in idle mode");	
-		}
+		Serial.println("ENS160 in idle mode");	
 	}
 	return this->_available;
 }

--- a/src/ScioSense_ENS160.cpp
+++ b/src/ScioSense_ENS160.cpp
@@ -99,17 +99,23 @@ bool ScioSense_ENS160::reset(void)
 bool ScioSense_ENS160::checkPartID(void) {
 	uint8_t i2cbuf[2];
 	uint16_t part_id;
+	bool result = false;
 	
 	this->read(_slaveaddr, ENS160_REG_PART_ID, i2cbuf, 2);
 	part_id = i2cbuf[0] | ((uint16_t)i2cbuf[1] << 8);
 	
 	if (debugENS160) {
 		Serial.print("checkPartID() result: ");
-		Serial.println(part_id == ENS160_PARTID ? "ok" : "nok");
+		if (part_id == ENS160_PARTID) Serial.println("ENS160 ok");
+		else if (part_id == ENS161_PARTID) Serial.println("ENS161 ok");
+		else Serial.println("nok");
 	}	
 	delay(ENS160_BOOTING);                   // Wait to boot after reset
+
+	if (part_id == ENS160_PARTID) { this->_revENS16x = 0; result = true; }
+	else if (part_id == ENS161_PARTID) { this->_revENS16x = 0; result = true; }
 	
-	return part_id == ENS160_PARTID;
+	return result;
 }
 
 // Initialize idle mode and confirms 

--- a/src/ScioSense_ENS160.cpp
+++ b/src/ScioSense_ENS160.cpp
@@ -373,8 +373,7 @@ bool ScioSense_ENS160::set_envdata210(uint16_t t, uint16_t h) {
 /**************************************************************************/
 
 void ScioSense_ENS160::_i2c_init() {
-	if (this->_sdaPin != this->_sclPin) Wire.begin(this->_sdaPin, this->_sclPin);
-	else Wire.begin();
+	Wire.begin();
 }
 
 /**************************************************************************/

--- a/src/ScioSense_ENS160.cpp
+++ b/src/ScioSense_ENS160.cpp
@@ -373,7 +373,11 @@ bool ScioSense_ENS160::set_envdata210(uint16_t t, uint16_t h) {
 /**************************************************************************/
 
 void ScioSense_ENS160::_i2c_init() {
-	Wire.begin();
+#if defined(ESP32)
+	if (this->_sdaPin != this->_sclPin) Wire.begin(this->_sdaPin, this->_sclPin);
+	else
+#endif
+	 Wire.begin();
 }
 
 /**************************************************************************/

--- a/src/ScioSense_ENS160.h
+++ b/src/ScioSense_ENS160.h
@@ -1,5 +1,6 @@
 /*
   ScioSense_ENS160.h - Library for the ENS160 sensor with I2C interface from ScioSense
+  2023 Mar 23	v6	Christoph Friese	Bugfix measurement routine, prepare next release
   2021 July 29	v4	Christoph Friese	Changed nomenclature to ScioSense as product shifted from ams
   2020 Apr 06	v3	Christoph Friese	Changed nomenclature to ScioSense as product shifted from ams
   2020 Feb 15	v2	Giuseppe Pasetti	Corrected firmware flash option

--- a/src/ScioSense_ENS160.h
+++ b/src/ScioSense_ENS160.h
@@ -21,6 +21,7 @@
 
 // Chip constants
 #define ENS160_PARTID				0x0160
+#define ENS161_PARTID				0x0161
 #define ENS160_BOOTING				10
 
 // 7-bit I2C slave address of the ENS160

--- a/src/ScioSense_ENS160.h
+++ b/src/ScioSense_ENS160.h
@@ -124,6 +124,7 @@ class ScioSense_ENS160 {
 		uint8_t				getAQI() 		{ return this->_data_aqi; }		// Get AQI value of last measurement 
 		uint16_t			getTVOC() 		{ return this->_data_tvoc; }		// Get TVOC value of last measurement 
 		uint16_t			geteCO2()		{ return this->_data_eco2; }		// Get eCO2 value of last measurement 
+		uint16_t			getAQI500() 		{ return this->_data_aqi500; }		// Get AQI500 value of last measurement 
 		uint32_t			getHP0() 		{ return this->_hp0_rs; }		// Get resistance of HP0 of last measurement
 		uint32_t			getHP1() 		{ return this->_hp1_rs; }		// Get resistance of HP1 of last measurement
 		uint32_t			getHP2() 		{ return this->_hp2_rs; }		// Get resistance of HP2 of last measurement
@@ -160,6 +161,7 @@ class ScioSense_ENS160 {
 		uint8_t				_data_aqi;
 		uint16_t			_data_tvoc;
 		uint16_t			_data_eco2;
+		uint16_t			_data_aqi500;
 		uint32_t			_hp0_rs;
 		uint32_t			_hp0_bl;
 		uint32_t			_hp1_rs;

--- a/src/ScioSense_ENS160.h
+++ b/src/ScioSense_ENS160.h
@@ -103,7 +103,7 @@ class ScioSense_ENS160 {
 
 		void 				setI2C(uint8_t sda, uint8_t scl);				// Function to redefine I2C pins
 		
-		bool 				begin(bool debug=false, bool bootloader=false);			// Init I2C communication, resets ENS160 and checks its PART_ID. Returns false on I2C problems or wrong PART_ID.
+		bool 				begin(bool debug=false);					// Init I2C communication, resets ENS160 and checks its PART_ID. Returns false on I2C problems or wrong PART_ID.
 		bool				available() 	{ return this->_available; }			// Report availability of sensor
 		uint8_t				revENS16x() 	{ return this->_revENS16x; }			// Report version of sensor (0: ENS160, 1: ENS161)
 		bool 				setMode(uint8_t mode);						// Set operation mode of sensor

--- a/src/ScioSense_ENS160.h
+++ b/src/ScioSense_ENS160.h
@@ -27,19 +27,19 @@
 #define ENS160_I2CADDR_1          	0x53		//ADDR high
 
 // ENS160 registers for version V0
-#define ENS160_REG_PART_ID          0x00 		// 2 byte register
-#define ENS160_REG_OPMODE			0x10
-#define ENS160_REG_CONFIG			0x11
-#define ENS160_REG_COMMAND			0x12
-#define ENS160_REG_TEMP_IN			0x13
-#define ENS160_REG_RH_IN			0x15
+#define ENS160_REG_PART_ID          	0x00 		// 2 byte register
+#define ENS160_REG_OPMODE		0x10
+#define ENS160_REG_CONFIG		0x11
+#define ENS160_REG_COMMAND		0x12
+#define ENS160_REG_TEMP_IN		0x13
+#define ENS160_REG_RH_IN		0x15
 #define ENS160_REG_DATA_STATUS		0x20
-#define ENS160_REG_DATA_AQI			0x21
+#define ENS160_REG_DATA_AQI		0x21
 #define ENS160_REG_DATA_TVOC		0x22
 #define ENS160_REG_DATA_ECO2		0x24			
-#define ENS160_REG_DATA_BL			0x28
-#define ENS160_REG_DATA_T			0x30
-#define ENS160_REG_DATA_RH			0x32
+#define ENS160_REG_DATA_BL		0x28
+#define ENS160_REG_DATA_T		0x30
+#define ENS160_REG_DATA_RH		0x32
 #define ENS160_REG_DATA_MISR		0x38
 #define ENS160_REG_GPR_WRITE_0		0x40
 #define ENS160_REG_GPR_WRITE_1		ENS160_REG_GPR_WRITE_0 + 1
@@ -55,26 +55,23 @@
 #define ENS160_REG_GPR_READ_7		ENS160_REG_GPR_READ_0 + 7
 
 //ENS160 data register fields
-#define ENS160_COMMAND_NOP			0x00
+#define ENS160_COMMAND_NOP		0x00
 #define ENS160_COMMAND_CLRGPR		0xCC
 #define ENS160_COMMAND_GET_APPVER	0x0E 
 #define ENS160_COMMAND_SETTH		0x02
 #define ENS160_COMMAND_SETSEQ		0xC2
 
-#define ENS160_OPMODE_RESET			0xF0
+#define ENS160_OPMODE_RESET		0xF0
 #define ENS160_OPMODE_DEP_SLEEP		0x00
-#define ENS160_OPMODE_IDLE			0x01
-#define ENS160_OPMODE_STD			0x02
-#define ENS160_OPMODE_INTERMEDIATE	0x03	
+#define ENS160_OPMODE_IDLE		0x01
+#define ENS160_OPMODE_STD		0x02
+#define ENS160_OPMODE_LP		0x03	
 #define ENS160_OPMODE_CUSTOM		0xC0
-#define ENS160_OPMODE_D0			0xD0
-#define ENS160_OPMODE_D1			0xD1
-#define ENS160_OPMODE_BOOTLOADER	0xB0
 
-#define ENS160_BL_CMD_START			0x02
+#define ENS160_BL_CMD_START		0x02
 #define ENS160_BL_CMD_ERASE_APP		0x04
 #define ENS160_BL_CMD_ERASE_BLINE	0x06
-#define ENS160_BL_CMD_WRITE			0x08
+#define ENS160_BL_CMD_WRITE		0x08
 #define ENS160_BL_CMD_VERIFY		0x0A
 #define ENS160_BL_CMD_GET_BLVER		0x0C
 #define ENS160_BL_CMD_GET_APPVER	0x0E
@@ -107,14 +104,15 @@ class ScioSense_ENS160 {
 		
 		bool 				begin(bool debug=false, bool bootloader=false);			// Init I2C communication, resets ENS160 and checks its PART_ID. Returns false on I2C problems or wrong PART_ID.
 		bool				available() 	{ return this->_available; }			// Report availability of sensor
-
+		uint8_t				revENS16x() 	{ return this->_revENS16x; }			// Report version of sensor (0: ENS160, 1: ENS161)
 		bool 				setMode(uint8_t mode);						// Set operation mode of sensor
 
 		bool 				initCustomMode(uint16_t stepNum);				// Initialize definition of custom mode with <n> steps
 		bool 				addCustomStep(uint16_t time, bool measureHP0, bool measureHP1, bool measureHP2, bool measureHP3, uint16_t tempHP0, uint16_t tempHP1, uint16_t tempHP2, uint16_t tempHP3);
 																							// Add a step to custom measurement profile with definition of duration, enabled data acquisition and temperature for each hotplate
 																							
-		bool 				measure(bool waitForNew = true); 				// Perfrom measurement and stores result in internal variables
+		bool 				measure(bool waitForNew = true); 				// Perform measurement and stores result in internal variables
+		bool 				measureRaw(bool waitForNew = true); 				// Perform raw measurement and stores result in internal variables
 		bool 				set_envdata(float t, float h);					// Writes t (degC) and h (%rh) to ENV_DATA. Returns "0" if I2C transmission is successful
 		bool 				set_envdata210(uint16_t t, uint16_t h);				// Writes t and h (in ENS210 format) to ENV_DATA. Returns "0" if I2C transmission is successful
 		uint8_t				getMajorRev() 	{ return this->_fw_ver_major; }			// Get major revision number of used firmware
@@ -149,7 +147,8 @@ class ScioSense_ENS160 {
 		bool				getFirmware();							// Read firmware revisions
 		
 		bool				_available = false;						// ENS160 available
-		
+		uint8_t				_revENS16x = 0;							// ENS160 or ENS161 connected? (FW >7)
+	
 		uint8_t				_fw_ver_major;
 		uint8_t 			_fw_ver_minor;
 		uint8_t				_fw_ver_build;
@@ -170,7 +169,6 @@ class ScioSense_ENS160 {
 		uint16_t			_temp;
 		int  				_slaveaddr;							// Slave address of the ENS160
 		uint8_t				_misr;
-
 		
 		//Isotherm, HP0 252°C / HP1 350°C / HP2 250°C / HP3 324°C / measure every 1008ms
 		uint8_t _seq_steps[1][8] = {


### PR DESCRIPTION
This updates our repo with the latest code from ScioSense. Tested on adafruit feather esp32 huzzah v2, and picow.
Also amends the libary.properties file to point here and mention it's an adafruit fork.

 It's worth noting the sparkfun driver includes getting the warm up status flag, which I found useful as the devices have a 1hour burn-in, but could not see the same functionality in the ScioSense driver
https://github.com/sparkfun/SparkFun_Indoor_Air_Quality_Sensor-ENS160_Arduino_Library/blob/be427d081346cfc12c5b6edef77bb27ea11569c9/src/sfe_ens160.cpp#L535